### PR TITLE
Fix through wall bug

### DIFF
--- a/src/collide_hit_rect.py
+++ b/src/collide_hit_rect.py
@@ -7,8 +7,6 @@ def collide_with_walls(group1: pygame.sprite.Group, group2: pygame.sprite.Group)
     hits = pygame.sprite.groupcollide(group1, group2, False, False, pygame.sprite.collide_rect_ratio(0.8))
     for sprite, walls in hits.items():
         sprite.collide_with_walls()
-        if isinstance(sprite, Player):
-            return
 
 
 def collide_with_bullets(group1: pygame.sprite.Group, group2: pygame.sprite.Group):


### PR DESCRIPTION
Fixed the bug where tanks will go through walls,

I figure ths cause of the issue was from the `collide_with_walls` function, as it uses a for loop to check all the detected collisions, but it gets interrupted after one collision has been detected, thus the tanks will just go through walls when multiple collisions happened.