### PR TITLE
Destructible supply stations

### DIFF
--- a/src/Station.py
+++ b/src/Station.py
@@ -22,14 +22,30 @@ class Station(pygame.sprite.Sprite):
         else:
             self.quadrant = 4
 
+        self.spawn_cd = kwargs["spawn_cd"]
+        self.cooldown = 0
+        self.is_alive = True
+
+    def update(self):
+        if not self.is_alive:
+            self.cooldown -= 1
+            if self.cooldown <= 0:
+                self.is_alive = True
+
+    def collect(self):
+        self.is_alive = False
+        self.cooldown = self.spawn_cd
+
     def get_data_from_obj_to_game(self):
         if 5 == self.id:
-            info = {"id": "oil", "x": self.rect.x, "y": self.rect.y, "power": self.power}
+            info = {"id": "oil", "x": self.rect.x, "y": self.rect.y, "power": self.power if self.is_alive else 0}
         else:
-            info = {"id": "bullets", "x": self.rect.x, "y": self.rect.y, "power": self.power}
+            info = {"id": "bullets", "x": self.rect.x, "y": self.rect.y, "power": self.power if self.is_alive else 0}
         return info
 
     def get_obj_progress_data(self):
+        if not self.is_alive:
+            return []
         if 5 == self.id:
             return create_image_view_data(f"oil", self.rect.x, self.rect.y
                                           , self.rect.width, self.rect.height, self.angle)

--- a/src/TeamBattleMode.py
+++ b/src/TeamBattleMode.py
@@ -183,14 +183,16 @@ class TeamBattleMode:
             # Check collision between player and stations
             bs = collide_with_stations(self.all_players, self.bullet_stations)
             os = collide_with_stations(self.all_players, self.oil_stations)
+            self.change_obj_pos(bs)
+            self.change_obj_pos(os)
 
             # Check collision between bullet and stations
             bs = collide_with_stations(self.bullets, self.bullet_stations)
             os = collide_with_stations(self.bullets, self.oil_stations)
-
-            # Update stations position
             self.change_obj_pos(bs)
             self.change_obj_pos(os)
+
+            # Update stations position
 
         player_score_data = collide_with_bullets(self.walls, self.bullets)
         for player in self.all_players:

--- a/src/TeamBattleMode.py
+++ b/src/TeamBattleMode.py
@@ -67,8 +67,8 @@ class TeamBattleMode:
         self.map.add_init_obj_data(PLAYER_1_IMG_NO, Player, act_cd=act_cd, play_rect_area=self.play_rect_area)
         self.map.add_init_obj_data(PLAYER_2_IMG_NO, Player, act_cd=act_cd, play_rect_area=self.play_rect_area)
         self.map.add_init_obj_data(WALL_IMG_NO, Wall, margin=8, spacing=8)
-        self.map.add_init_obj_data(BULLET_STATION_IMG_NO, Station, margin=2, spacing=2, capacity=5, quadrant=1)
-        self.map.add_init_obj_data(OIL_STATION_IMG_NO, Station, margin=2, spacing=2, capacity=30, quadrant=1)
+        self.map.add_init_obj_data(BULLET_STATION_IMG_NO, Station, spawn_cd=30, margin=2, spacing=2, capacity=5, quadrant=1)
+        self.map.add_init_obj_data(OIL_STATION_IMG_NO, Station, spawn_cd=30, margin=2, spacing=2, capacity=30, quadrant=1)
         # create obj
         all_obj = self.map.create_init_obj_dict()
         # init players
@@ -114,6 +114,8 @@ class TeamBattleMode:
         self.walls.update()
         self.create_bullet(self.all_players)
         self.bullets.update()
+        self.bullet_stations.update()
+        self.oil_stations.update()
         self.all_players.update(command)
         self.get_player_end()
         if self.used_frame >= self.frame_limit:

--- a/src/TeamBattleMode.py
+++ b/src/TeamBattleMode.py
@@ -179,10 +179,19 @@ class TeamBattleMode:
             for player in player_score_data.keys():
                 self.add_player_score(player)
             # TODO refactor stations
-            bs = collide_with_bullet_stations(self.all_players, self.bullet_stations)
+
+            # Check collision between player and stations
+            bs = collide_with_stations(self.all_players, self.bullet_stations)
+            os = collide_with_stations(self.all_players, self.oil_stations)
+
+            # Check collision between bullet and stations
+            bs = collide_with_stations(self.bullets, self.bullet_stations)
+            os = collide_with_stations(self.bullets, self.oil_stations)
+
+            # Update stations position
             self.change_obj_pos(bs)
-            os = collide_with_oil_stations(self.all_players, self.oil_stations)
             self.change_obj_pos(os)
+
         player_score_data = collide_with_bullets(self.walls, self.bullets)
         for player in self.all_players:
             if player.no in player_score_data.keys() and isinstance(player, Player):

--- a/src/TeamBattleMode.py
+++ b/src/TeamBattleMode.py
@@ -180,19 +180,18 @@ class TeamBattleMode:
                 self.add_player_score(player, score)
             # TODO refactor stations
 
-            # Check collision between player and stations
-            bs = collide_with_stations(self.all_players, self.bullet_stations)
-            os = collide_with_stations(self.all_players, self.oil_stations)
-            self.change_obj_pos(bs)
-            self.change_obj_pos(os)
+            supply_stations = []
 
-            # Check collision between bullet and stations
-            bs = collide_with_stations(self.bullets, self.bullet_stations)
-            os = collide_with_stations(self.bullets, self.oil_stations)
-            self.change_obj_pos(bs)
-            self.change_obj_pos(os)
+            # Check collision between player and supply stations
+            supply_stations.extend(collide_with_supply_stations(self.all_players, self.bullet_stations))
+            supply_stations.extend(collide_with_supply_stations(self.all_players, self.oil_stations))
+
+            # Check collision between bullet and supply stations
+            supply_stations.extend(collide_with_supply_stations(self.bullets, self.bullet_stations))
+            supply_stations.extend(collide_with_supply_stations(self.bullets, self.oil_stations))
 
             # Update stations position
+            self.change_obj_pos(supply_stations)
 
         player_score_data = collide_with_bullets(self.walls, self.bullets)
         for player, score in player_score_data.items():

--- a/src/collide_hit_rect.py
+++ b/src/collide_hit_rect.py
@@ -1,6 +1,7 @@
 import pygame.sprite
 
 from src.Player import Player
+from src.Bullet import Bullet
 
 
 def collide_with_walls(group1: pygame.sprite.Group, group2: pygame.sprite.Group):
@@ -27,17 +28,13 @@ def collide_with_bullets(group1: pygame.sprite.Group, group2: pygame.sprite.Grou
     return player_score_data
 
 
-def collide_with_bullet_stations(player: pygame.sprite.Group, stations: pygame.sprite.Group):
-    hits = pygame.sprite.groupcollide(player, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
-    for player, stations in hits.items():
-        player.get_power(stations[0].power)
-        stations[0].collect()
-        return stations
+def collide_with_stations(sprites: pygame.sprite.Group, stations: pygame.sprite.Group):
+    hits = pygame.sprite.groupcollide(sprites, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
+    for sprite, stations in hits.items():
+        if isinstance(sprite, Player):
+            sprite.get_oil(stations[0].power)
+        elif isinstance(sprite, Bullet):
+            sprite.kill()
 
-
-def collide_with_oil_stations(player: pygame.sprite.Group, stations: pygame.sprite.Group):
-    hits = pygame.sprite.groupcollide(player, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
-    for player, stations in hits.items():
-        player.get_oil(stations[0].power)
         stations[0].collect()
         return stations

--- a/src/collide_hit_rect.py
+++ b/src/collide_hit_rect.py
@@ -42,13 +42,17 @@ def collide_with_bullets(group1: pygame.sprite.Group, group2: pygame.sprite.Grou
     return player_score_data
 
 
-def collide_with_stations(sprites: pygame.sprite.Group, stations: pygame.sprite.Group):
-    hits = pygame.sprite.groupcollide(sprites, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
-    for sprite, stations in hits.items():
+def collide_with_supply_stations(sprites: pygame.sprite.Group, supply_stations: pygame.sprite.Group):
+    hits = pygame.sprite.groupcollide(sprites, supply_stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
+    for sprite, supply_station in hits.items():
         if isinstance(sprite, Player):
-            sprite.get_oil(stations[0].power)
+            if supply_station[0].id == 5:
+                sprite.get_oil(supply_station[0].power)
+            else:
+                sprite.get_power(supply_station[0].power)
         elif isinstance(sprite, Bullet):
             sprite.kill()
 
-        stations[0].collect()
-        return stations
+        supply_station[0].collect()
+
+    return [supply_station[0] for supply_station in hits.values()]

--- a/src/collide_hit_rect.py
+++ b/src/collide_hit_rect.py
@@ -31,6 +31,7 @@ def collide_with_bullet_stations(player: pygame.sprite.Group, stations: pygame.s
     hits = pygame.sprite.groupcollide(player, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
     for player, stations in hits.items():
         player.get_power(stations[0].power)
+        stations[0].collect()
         return stations
 
 
@@ -38,4 +39,5 @@ def collide_with_oil_stations(player: pygame.sprite.Group, stations: pygame.spri
     hits = pygame.sprite.groupcollide(player, stations, False, False, pygame.sprite.collide_rect_ratio(0.8))
     for player, stations in hits.items():
         player.get_oil(stations[0].power)
+        stations[0].collect()
         return stations


### PR DESCRIPTION
This change introduces spawn cooldown for supply stations, as well as making them destructible with bullets.

![demo](https://github.com/Jesse-Jumbo/TankMan/assets/20783502/aa881a81-98c3-4001-84ed-3a01afa315bd)

The returned power values are set to 0 after a supply station has been collected and yet to respawn.